### PR TITLE
Discard master-slave lingo

### DIFF
--- a/bookshelf/venv/Lib/site-packages/django/apps/registry.py
+++ b/bookshelf/venv/Lib/site-packages/django/apps/registry.py
@@ -18,7 +18,7 @@ class Apps:
     """
 
     def __init__(self, installed_apps=()):
-        # installed_apps is set to None when creating the master registry
+        # installed_apps is set to None when creating the main registry
         # because it cannot be populated at that point. Other registries must
         # provide a list of installed apps and are populated immediately.
         if installed_apps is None and hasattr(sys.modules[__name__], 'apps'):
@@ -52,7 +52,7 @@ class Apps:
         # `lazy_model_operation()` and `do_pending_operations()` methods.
         self._pending_operations = defaultdict(list)
 
-        # Populate apps and models, unless it's the master registry.
+        # Populate apps and models, unless it's the main registry.
         if installed_apps is not None:
             self.populate(installed_apps)
 

--- a/bookshelf/venv/Lib/site-packages/django/conf/global_settings.py
+++ b/bookshelf/venv/Lib/site-packages/django/conf/global_settings.py
@@ -215,7 +215,7 @@ FORM_RENDERER = 'django.forms.renderers.DjangoTemplates'
 
 # Default email address to use for various automated correspondence from
 # the site managers.
-DEFAULT_FROM_EMAIL = 'webmaster@localhost'
+DEFAULT_FROM_EMAIL = 'webmain@localhost'
 
 # Subject-line prefix for email messages send with django.core.mail.mail_admins
 # or ...mail_managers.  Make sure to include the trailing space.

--- a/bookshelf/venv/Lib/sre_parse.py
+++ b/bookshelf/venv/Lib/sre_parse.py
@@ -72,7 +72,7 @@ class Verbose(Exception):
     pass
 
 class Pattern:
-    # master pattern object.  keeps track of global attributes
+    # main pattern object.  keeps track of global attributes
     def __init__(self):
         self.flags = 0
         self.groupdict = {}

--- a/forms/venv/lib/python3.6/site-packages/django/apps/registry.py
+++ b/forms/venv/lib/python3.6/site-packages/django/apps/registry.py
@@ -18,7 +18,7 @@ class Apps:
     """
 
     def __init__(self, installed_apps=()):
-        # installed_apps is set to None when creating the master registry
+        # installed_apps is set to None when creating the main registry
         # because it cannot be populated at that point. Other registries must
         # provide a list of installed apps and are populated immediately.
         if installed_apps is None and hasattr(sys.modules[__name__], 'apps'):
@@ -54,7 +54,7 @@ class Apps:
         # `lazy_model_operation()` and `do_pending_operations()` methods.
         self._pending_operations = defaultdict(list)
 
-        # Populate apps and models, unless it's the master registry.
+        # Populate apps and models, unless it's the main registry.
         if installed_apps is not None:
             self.populate(installed_apps)
 

--- a/forms/venv/lib/python3.6/site-packages/django/conf/global_settings.py
+++ b/forms/venv/lib/python3.6/site-packages/django/conf/global_settings.py
@@ -216,7 +216,7 @@ FORM_RENDERER = 'django.forms.renderers.DjangoTemplates'
 
 # Default email address to use for various automated correspondence from
 # the site managers.
-DEFAULT_FROM_EMAIL = 'webmaster@localhost'
+DEFAULT_FROM_EMAIL = 'webmain@localhost'
 
 # Subject-line prefix for email messages send with django.core.mail.mail_admins
 # or ...mail_managers.  Make sure to include the trailing space.

--- a/forms/venv/lib/python3.6/site-packages/django/db/backends/sqlite3/introspection.py
+++ b/forms/venv/lib/python3.6/site-packages/django/db/backends/sqlite3/introspection.py
@@ -68,7 +68,7 @@ class DatabaseIntrospection(BaseDatabaseIntrospection):
         # Skip the sqlite_sequence system table used for autoincrement key
         # generation.
         cursor.execute("""
-            SELECT name, type FROM sqlite_master
+            SELECT name, type FROM sqlite_main
             WHERE type in ('table', 'view') AND NOT name='sqlite_sequence'
             ORDER BY name""")
         return [TableInfo(row[0], row[1][0]) for row in cursor.fetchall()]
@@ -106,7 +106,7 @@ class DatabaseIntrospection(BaseDatabaseIntrospection):
 
         # Schema for this table
         cursor.execute(
-            "SELECT sql, type FROM sqlite_master "
+            "SELECT sql, type FROM sqlite_main "
             "WHERE tbl_name = %s AND type IN ('table', 'view')",
             [table_name]
         )
@@ -136,7 +136,7 @@ class DatabaseIntrospection(BaseDatabaseIntrospection):
             else:
                 field_name = field_desc.split()[0].strip('"')
 
-            cursor.execute("SELECT sql FROM sqlite_master WHERE tbl_name = %s", [table])
+            cursor.execute("SELECT sql FROM sqlite_main WHERE tbl_name = %s", [table])
             result = cursor.fetchall()[0]
             other_table_results = result[0].strip()
             li, ri = other_table_results.index('('), other_table_results.rindex(')')
@@ -162,7 +162,7 @@ class DatabaseIntrospection(BaseDatabaseIntrospection):
         key_columns = []
 
         # Schema for this table
-        cursor.execute("SELECT sql FROM sqlite_master WHERE tbl_name = %s AND type = %s", [table_name, "table"])
+        cursor.execute("SELECT sql FROM sqlite_main WHERE tbl_name = %s AND type = %s", [table_name, "table"])
         results = cursor.fetchone()[0].strip()
         results = results[results.index('(') + 1:results.rindex(')')]
 
@@ -187,7 +187,7 @@ class DatabaseIntrospection(BaseDatabaseIntrospection):
         """Return the column name of the primary key for the given table."""
         # Don't use PRAGMA because that causes issues with some transactions
         cursor.execute(
-            "SELECT sql, type FROM sqlite_master "
+            "SELECT sql, type FROM sqlite_main "
             "WHERE tbl_name = %s AND type IN ('table', 'view')",
             [table_name]
         )
@@ -363,7 +363,7 @@ class DatabaseIntrospection(BaseDatabaseIntrospection):
         # Find inline check constraints.
         try:
             table_schema = cursor.execute(
-                "SELECT sql FROM sqlite_master WHERE type='table' and name=%s" % (
+                "SELECT sql FROM sqlite_main WHERE type='table' and name=%s" % (
                     self.connection.ops.quote_name(table_name),
                 )
             ).fetchone()[0]
@@ -381,7 +381,7 @@ class DatabaseIntrospection(BaseDatabaseIntrospection):
             # columns. Discard last 2 columns if there.
             number, index, unique = row[:3]
             cursor.execute(
-                "SELECT sql FROM sqlite_master "
+                "SELECT sql FROM sqlite_main "
                 "WHERE type='index' AND name=%s" % self.connection.ops.quote_name(index)
             )
             # There's at most one row.

--- a/forms/venv/lib/python3.6/site-packages/django/db/backends/sqlite3/operations.py
+++ b/forms/venv/lib/python3.6/site-packages/django/db/backends/sqlite3/operations.py
@@ -171,8 +171,8 @@ class DatabaseOperations(BaseDatabaseOperations):
         WITH tables AS (
             SELECT %s name
             UNION
-            SELECT sqlite_master.name
-            FROM sqlite_master
+            SELECT sqlite_main.name
+            FROM sqlite_main
             JOIN tables ON (sql REGEXP %s || tables.name || %s)
         ) SELECT name FROM tables;
         """

--- a/forms/venv/lib/python3.6/site-packages/django/db/backends/sqlite3/schema.py
+++ b/forms/venv/lib/python3.6/site-packages/django/db/backends/sqlite3/schema.py
@@ -122,15 +122,15 @@ class DatabaseSchemaEditor(BaseDatabaseSchemaEditor):
                     new_column_name = new_field.get_attname_column()[1]
                     search = references_template % old_column_name
                     replacement = references_template % new_column_name
-                    cursor.execute('UPDATE sqlite_master SET sql = replace(sql, %s, %s)', (search, replacement))
+                    cursor.execute('UPDATE sqlite_main SET sql = replace(sql, %s, %s)', (search, replacement))
                     cursor.execute('PRAGMA schema_version = %d' % (schema_version + 1))
                     cursor.execute('PRAGMA writable_schema = 0')
                     # The integrity check will raise an exception and rollback
-                    # the transaction if the sqlite_master updates corrupt the
+                    # the transaction if the sqlite_main updates corrupt the
                     # database.
                     cursor.execute('PRAGMA integrity_check')
             # Perform a VACUUM to refresh the database representation from
-            # the sqlite_master table.
+            # the sqlite_main table.
             with self.connection.cursor() as cursor:
                 cursor.execute('VACUUM')
         else:

--- a/forms/venv/lib/python3.6/site-packages/django/test/client.py
+++ b/forms/venv/lib/python3.6/site-packages/django/test/client.py
@@ -464,7 +464,7 @@ class Client(RequestFactory):
 
     def request(self, **request):
         """
-        The master request method. Compose the environment dictionary and pass
+        The main request method. Compose the environment dictionary and pass
         to the handler, return the result of the handler. Assume defaults for
         the query environment, which can be overridden using the arguments to
         the request.

--- a/forms/venv/lib/python3.6/site-packages/django/test/runner.py
+++ b/forms/venv/lib/python3.6/site-packages/django/test/runner.py
@@ -76,7 +76,7 @@ class RemoteTestResult:
     Record information about which tests have succeeded and which have failed.
 
     The sole purpose of this class is to record events in the child processes
-    so they can be replayed in the master process. As a consequence it doesn't
+    so they can be replayed in the main process. As a consequence it doesn't
     inherit unittest.TestResult and doesn't attempt to implement all its API.
 
     The implementation matches the unpythonic coding style of unittest2.

--- a/forms/venv/lib/python3.6/site-packages/pip/vcs/git.py
+++ b/forms/venv/lib/python3.6/site-packages/pip/vcs/git.py
@@ -118,7 +118,7 @@ class Git(VersionControl):
             self.run_command(['fetch', '-q', '--tags'], cwd=dest)
         else:
             self.run_command(['fetch', '-q'], cwd=dest)
-        # Then reset to wanted revision (maybe even origin/master)
+        # Then reset to wanted revision (maybe even origin/main)
         if rev_options:
             rev_options = self.check_rev_options(
                 rev_options[0], dest, rev_options,
@@ -133,7 +133,7 @@ class Git(VersionControl):
             rev_options = [rev]
             rev_display = ' (to %s)' % rev
         else:
-            rev_options = ['origin/master']
+            rev_options = ['origin/main']
             rev_display = ''
         if self.check_destination(dest, url, rev_options, rev_display):
             logger.info(

--- a/forms/venv/lib/python3.6/site-packages/pkg_resources/__init__.py
+++ b/forms/venv/lib/python3.6/site-packages/pkg_resources/__init__.py
@@ -558,9 +558,9 @@ class WorkingSet(object):
             self.add_entry(entry)
 
     @classmethod
-    def _build_master(cls):
+    def _build_main(cls):
         """
-        Prepare the master working set.
+        Prepare the main working set.
         """
         ws = cls()
         try:
@@ -3086,9 +3086,9 @@ def _initialize(g=globals()):
 
 
 @_call_aside
-def _initialize_master_working_set():
+def _initialize_main_working_set():
     """
-    Prepare the master working set and make the ``require()``
+    Prepare the main working set and make the ``require()``
     API available.
 
     This function has explicit effects on the global state
@@ -3098,7 +3098,7 @@ def _initialize_master_working_set():
     Invocation by other packages is unsupported and done
     at their own risk.
     """
-    working_set = WorkingSet._build_master()
+    working_set = WorkingSet._build_main()
     _declare_state('object', working_set=working_set)
 
     require = working_set.require

--- a/forms/venv/lib/python3.6/site-packages/setuptools/command/easy_install.py
+++ b/forms/venv/lib/python3.6/site-packages/setuptools/command/easy_install.py
@@ -1830,7 +1830,7 @@ def update_dist_caches(dist_path, fix_zipimporter_caches):
     # There are several other known sources of stale zipimport.zipimporter
     # instances that we do not clear here, but might if ever given a reason to
     # do so:
-    # * Global setuptools pkg_resources.working_set (a.k.a. 'master working
+    # * Global setuptools pkg_resources.working_set (a.k.a. 'main working
     # set') may contain distributions which may in turn contain their
     #   zipimport.zipimporter loaders.
     # * Several zipimport.zipimporter loaders held by local variables further

--- a/site/venv/lib/python3.6/site-packages/django/apps/registry.py
+++ b/site/venv/lib/python3.6/site-packages/django/apps/registry.py
@@ -18,7 +18,7 @@ class Apps:
     """
 
     def __init__(self, installed_apps=()):
-        # installed_apps is set to None when creating the master registry
+        # installed_apps is set to None when creating the main registry
         # because it cannot be populated at that point. Other registries must
         # provide a list of installed apps and are populated immediately.
         if installed_apps is None and hasattr(sys.modules[__name__], 'apps'):
@@ -52,7 +52,7 @@ class Apps:
         # `lazy_model_operation()` and `do_pending_operations()` methods.
         self._pending_operations = defaultdict(list)
 
-        # Populate apps and models, unless it's the master registry.
+        # Populate apps and models, unless it's the main registry.
         if installed_apps is not None:
             self.populate(installed_apps)
 

--- a/site/venv/lib/python3.6/site-packages/django/conf/global_settings.py
+++ b/site/venv/lib/python3.6/site-packages/django/conf/global_settings.py
@@ -215,7 +215,7 @@ FORM_RENDERER = 'django.forms.renderers.DjangoTemplates'
 
 # Default email address to use for various automated correspondence from
 # the site managers.
-DEFAULT_FROM_EMAIL = 'webmaster@localhost'
+DEFAULT_FROM_EMAIL = 'webmain@localhost'
 
 # Subject-line prefix for email messages send with django.core.mail.mail_admins
 # or ...mail_managers.  Make sure to include the trailing space.

--- a/site/venv/lib/python3.6/site-packages/django/db/backends/sqlite3/introspection.py
+++ b/site/venv/lib/python3.6/site-packages/django/db/backends/sqlite3/introspection.py
@@ -60,7 +60,7 @@ class DatabaseIntrospection(BaseDatabaseIntrospection):
         # Skip the sqlite_sequence system table used for autoincrement key
         # generation.
         cursor.execute("""
-            SELECT name, type FROM sqlite_master
+            SELECT name, type FROM sqlite_main
             WHERE type in ('table', 'view') AND NOT name='sqlite_sequence'
             ORDER BY name""")
         return [TableInfo(row[0], row[1][0]) for row in cursor.fetchall()]
@@ -97,7 +97,7 @@ class DatabaseIntrospection(BaseDatabaseIntrospection):
 
         # Schema for this table
         cursor.execute(
-            "SELECT sql, type FROM sqlite_master "
+            "SELECT sql, type FROM sqlite_main "
             "WHERE tbl_name = %s AND type IN ('table', 'view')",
             [table_name]
         )
@@ -127,7 +127,7 @@ class DatabaseIntrospection(BaseDatabaseIntrospection):
             else:
                 field_name = field_desc.split()[0].strip('"')
 
-            cursor.execute("SELECT sql FROM sqlite_master WHERE tbl_name = %s", [table])
+            cursor.execute("SELECT sql FROM sqlite_main WHERE tbl_name = %s", [table])
             result = cursor.fetchall()[0]
             other_table_results = result[0].strip()
             li, ri = other_table_results.index('('), other_table_results.rindex(')')
@@ -153,7 +153,7 @@ class DatabaseIntrospection(BaseDatabaseIntrospection):
         key_columns = []
 
         # Schema for this table
-        cursor.execute("SELECT sql FROM sqlite_master WHERE tbl_name = %s AND type = %s", [table_name, "table"])
+        cursor.execute("SELECT sql FROM sqlite_main WHERE tbl_name = %s AND type = %s", [table_name, "table"])
         results = cursor.fetchone()[0].strip()
         results = results[results.index('(') + 1:results.rindex(')')]
 
@@ -178,7 +178,7 @@ class DatabaseIntrospection(BaseDatabaseIntrospection):
         """Return the column name of the primary key for the given table."""
         # Don't use PRAGMA because that causes issues with some transactions
         cursor.execute(
-            "SELECT sql, type FROM sqlite_master "
+            "SELECT sql, type FROM sqlite_main "
             "WHERE tbl_name = %s AND type IN ('table', 'view')",
             [table_name]
         )
@@ -255,7 +255,7 @@ class DatabaseIntrospection(BaseDatabaseIntrospection):
                 # SQLite doesn't support any index type other than b-tree
                 constraints[index]['type'] = Index.suffix
                 cursor.execute(
-                    "SELECT sql FROM sqlite_master "
+                    "SELECT sql FROM sqlite_main "
                     "WHERE type='index' AND name=%s" % self.connection.ops.quote_name(index)
                 )
                 orders = []

--- a/site/venv/lib/python3.6/site-packages/django/db/backends/sqlite3/schema.py
+++ b/site/venv/lib/python3.6/site-packages/django/db/backends/sqlite3/schema.py
@@ -121,15 +121,15 @@ class DatabaseSchemaEditor(BaseDatabaseSchemaEditor):
                     new_column_name = new_field.get_attname_column()[1]
                     search = references_template % old_column_name
                     replacement = references_template % new_column_name
-                    cursor.execute('UPDATE sqlite_master SET sql = replace(sql, %s, %s)', (search, replacement))
+                    cursor.execute('UPDATE sqlite_main SET sql = replace(sql, %s, %s)', (search, replacement))
                     cursor.execute('PRAGMA schema_version = %d' % (schema_version + 1))
                     cursor.execute('PRAGMA writable_schema = 0')
                     # The integrity check will raise an exception and rollback
-                    # the transaction if the sqlite_master updates corrupt the
+                    # the transaction if the sqlite_main updates corrupt the
                     # database.
                     cursor.execute('PRAGMA integrity_check')
             # Perform a VACUUM to refresh the database representation from
-            # the sqlite_master table.
+            # the sqlite_main table.
             with self.connection.cursor() as cursor:
                 cursor.execute('VACUUM')
         else:

--- a/site/venv/lib/python3.6/site-packages/django/test/client.py
+++ b/site/venv/lib/python3.6/site-packages/django/test/client.py
@@ -456,7 +456,7 @@ class Client(RequestFactory):
 
     def request(self, **request):
         """
-        The master request method. Compose the environment dictionary and pass
+        The main request method. Compose the environment dictionary and pass
         to the handler, return the result of the handler. Assume defaults for
         the query environment, which can be overridden using the arguments to
         the request.

--- a/site/venv/lib/python3.6/site-packages/django/test/runner.py
+++ b/site/venv/lib/python3.6/site-packages/django/test/runner.py
@@ -76,7 +76,7 @@ class RemoteTestResult:
     Record information about which tests have succeeded and which have failed.
 
     The sole purpose of this class is to record events in the child processes
-    so they can be replayed in the master process. As a consequence it doesn't
+    so they can be replayed in the main process. As a consequence it doesn't
     inherit unittest.TestResult and doesn't attempt to implement all its API.
 
     The implementation matches the unpythonic coding style of unittest2.

--- a/site/venv/lib/python3.6/site-packages/pip-10.0.1-py3.6.egg/pip/_internal/vcs/git.py
+++ b/site/venv/lib/python3.6/site-packages/pip-10.0.1-py3.6.egg/pip/_internal/vcs/git.py
@@ -169,7 +169,7 @@ class Git(VersionControl):
             self.run_command(['fetch', '-q', '--tags'], cwd=dest)
         else:
             self.run_command(['fetch', '-q'], cwd=dest)
-        # Then reset to wanted revision (maybe even origin/master)
+        # Then reset to wanted revision (maybe even origin/main)
         rev_options = self.check_rev_options(dest, rev_options)
         cmd_args = ['reset', '--hard', '-q'] + rev_options.to_args()
         self.run_command(cmd_args, cwd=dest)

--- a/site/venv/lib/python3.6/site-packages/pip-10.0.1-py3.6.egg/pip/_vendor/pkg_resources/__init__.py
+++ b/site/venv/lib/python3.6/site-packages/pip-10.0.1-py3.6.egg/pip/_vendor/pkg_resources/__init__.py
@@ -558,9 +558,9 @@ class WorkingSet(object):
             self.add_entry(entry)
 
     @classmethod
-    def _build_master(cls):
+    def _build_main(cls):
         """
-        Prepare the master working set.
+        Prepare the main working set.
         """
         ws = cls()
         try:
@@ -3086,9 +3086,9 @@ def _initialize(g=globals()):
 
 
 @_call_aside
-def _initialize_master_working_set():
+def _initialize_main_working_set():
     """
-    Prepare the master working set and make the ``require()``
+    Prepare the main working set and make the ``require()``
     API available.
 
     This function has explicit effects on the global state
@@ -3098,7 +3098,7 @@ def _initialize_master_working_set():
     Invocation by other packages is unsupported and done
     at their own risk.
     """
-    working_set = WorkingSet._build_master()
+    working_set = WorkingSet._build_main()
     _declare_state('object', working_set=working_set)
 
     require = working_set.require


### PR DESCRIPTION
For diversity reasons, it would be nice to try to avoid 'master' and 'slave' terminology in this repository which can be associated to slavery. The master-slave terminology could be problematic for people in several countries which has the history of slavery like Romania, USA and many others. Thank you for considering the proposal. Let me know if any changes in the PR are needed, I would be happy to implement them.